### PR TITLE
Update references to hardcoded outdated module versions; remove old repositories

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -1,4 +1,4 @@
-ext.version = "1.0.1"
+ext.version = "1.0.2"
 ext.group = "nz.co.trademe.plunge"
 ext.repo = "plunge"
 ext.org = "trademe"

--- a/plunge-gradle-plugin/build.gradle
+++ b/plunge-gradle-plugin/build.gradle
@@ -10,7 +10,6 @@ apply from: '../publishing.gradle'
 
 repositories {
     google()
-    jcenter()
     mavenLocal()
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url  "https://dl.bintray.com/trademe/Plunge" }
@@ -24,5 +23,5 @@ dependencies {
     implementation "com.android.tools.build:gradle:$android_gradle_plugin_version"
 
     // Plunge parsing
-    implementation "nz.co.trademe.plunge:plunge-parsing:1.0.0"
+    implementation "nz.co.trademe.plunge:plunge-parsing:$project.ext.version"
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
+    apply from: '../common.gradle'
+
     repositories {
         google()
-        jcenter()
         mavenLocal()
-        maven { url "https://kotlin.bintray.com/kotlinx" }
-        maven { url  "https://dl.bintray.com/trademe/Plunge" }
+        mavenCentral()
     }
     dependencies {
-        classpath "nz.co.trademe.plunge:plunge-gradle-plugin:1.0.0"
+        classpath "nz.co.trademe.plunge:plunge-gradle-plugin:$project.ext.version"
     }
 }
 


### PR DESCRIPTION
The current version (1.0.1) has some hardcoded references to the 1.0.0 of some modules, which prevent projects from syncing exclusively from `mavenCentral` (as 1.0.0 is only available in `jcenter`). To fix this, I've replaced these references with `$project.ext.version` to ensure all modules are always built and published in sync.

I've also removed some old (dead) repos from the buildscripts!

Please let me know when you release this as `1.0.2` so I can remove `jcenter` from my projects 😄 


Cheers!