### PR TITLE
Fix dependency versioning

### DIFF
--- a/plunge-gradle-plugin/build.gradle
+++ b/plunge-gradle-plugin/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     implementation "com.android.tools.build:gradle:$android_gradle_plugin_version"
 
     // Plunge parsing
-    implementation "nz.co.trademe.plunge:plunge-parsing:$project.ext.version"
+    implementation project(':plunge-parsing')
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -5,9 +5,10 @@ buildscript {
         google()
         mavenLocal()
         mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath "nz.co.trademe.plunge:plunge-gradle-plugin:$project.ext.version"
+        classpath "nz.co.trademe.plunge:plunge-gradle-plugin:1.0.1"
     }
 }
 


### PR DESCRIPTION
There was a problem with publishing after merging https://github.com/TradeMe/Plunge/pull/11.

(We really should have an action to check build before merging)

The dependencies were set up to use a version that does not exist in any repo.
* `plunge-gradle-plugin/build.gradle`: change to depend on the local project instead
* `sample/build.gradle`: change to depend on the latest version that exists on maven central, which itself has a [dependency](https://search.maven.org/artifact/nz.co.trademe.plunge/plunge-gradle-plugin/1.0.1/jar) on 1.0.0 of `nz.co.trademe.plunge:plunge-parsing` (this at the moment only exists on jcenter). 